### PR TITLE
[ITA-958] Add missing features to Web-WebView

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,14 @@ Supported props are:
 
 - `source`
 - `onMessage`
+- `onLoadEnd`
 - `scrollEnabled`
 - `injectedJavaScript`
 - `style`
+
+Supported methods are:
+
+- `injectJavaScript`
 
 Additional, web-specific props are:
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-web-webview",
   "version": "1.0.2",
   "description": "React Native for Web implementation of RN's WebView",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "main-es": "src/index.js",
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -9,12 +9,12 @@ export class WebView extends Component {
 
   constructor(props) {
     super(props);
-    
+
     this.state = {
       html: props.source.html,
       baseUrl: props.source.baseUrl,
       injectedJavaScript: props.injectedJavaScript,
-    }
+    };
 
     if (props.source.uri) {
       if (props.newWindow) {
@@ -31,8 +31,8 @@ export class WebView extends Component {
     const { uri, ...options } = source;
     const baseUrl = uri.substr(0, uri.lastIndexOf('/') + 1);
     fetch(uri, options)
-      .then(response => response.text())
-      .then(html => this.setState({ html, baseUrl }));
+      .then((response) => response.text())
+      .then((html) => this.setState({ html, baseUrl }));
   };
 
   getSourceDocument = () => {
@@ -50,14 +50,17 @@ export class WebView extends Component {
       doc = doc.replace('</body>', `<script>window.ReactNativeWebView = window.parent;</script></body>`);
     }
     if (this.props.onLoadEnd) {
-      doc = doc.replace('</body>', `<script>document.addEventListener("DOMContentLoaded", function () { window.parent.postMessage('DOMContentLoaded'); })</script></body>`);
+      doc = doc.replace(
+        '</body>',
+        `<script>document.addEventListener("DOMContentLoaded", function () { window.parent.postMessage('DOMContentLoaded'); })</script></body>`
+      );
     }
     if (injectedJavaScript) {
       doc = doc.replace('</body>', `<script>${injectedJavaScript}</script></body>`);
     }
 
     return doc;
-  }
+  };
 
   handleSourceInNewWindow = (source, newWindow) => {
     if (source.method === 'POST') {
@@ -117,7 +120,7 @@ export class WebView extends Component {
     if (typeof this.props.onLoadEnd === 'function' && nativeEvent.data === 'DOMContentLoaded') {
       this.props.onLoadEnd();
     } else if (typeof this.props.onMessage === 'function') {
-      this.props.onMessage({ nativeEvent })
+      this.props.onMessage({ nativeEvent });
     }
   };
 


### PR DESCRIPTION
I forked the original [react-native-web-webview](https://github.com/react-native-web-community/react-native-web-webview) repository and fixed / added a couple things:
- Better implementation for `injectedJavaScript` prop which shouldn't inject the JS code multiple times in case the HTML source changes.
- The `method` field in the `source` prop object defaults to `GET` in the original package, changed the implementation here as well to behave the same way.
- Implement the `injectJavascript` method on the component.
- Add support for the `onLoadEnd` prop.
- `react-native-webview` on its supported platforms injects the `ReactNativeWebView` variable on the `window` inside the WebView. Replicated this behaviour here as well.